### PR TITLE
Multiple code improvements - squid:S1118, squid:S1854, squid:S1165, squid:S2885

### DIFF
--- a/src/main/java/de/timroes/axmlrpc/XMLRPCServerException.java
+++ b/src/main/java/de/timroes/axmlrpc/XMLRPCServerException.java
@@ -8,7 +8,7 @@ package de.timroes.axmlrpc;
  */
 public class XMLRPCServerException extends XMLRPCException {
 
-	private int errornr;
+	private final int errornr;
 
 	public XMLRPCServerException(String ex, int errnr) {
 		super(ex);

--- a/src/main/java/de/timroes/axmlrpc/XMLUtil.java
+++ b/src/main/java/de/timroes/axmlrpc/XMLUtil.java
@@ -12,6 +12,8 @@ import org.w3c.dom.NodeList;
  */
 public class XMLUtil {
 
+	private XMLUtil() {}
+
 	/**
 	 * Returns the only child element in a given NodeList.
 	 * Will throw an error if there is more then one child element or any other

--- a/src/main/java/de/timroes/axmlrpc/serializer/DateTimeSerializer.java
+++ b/src/main/java/de/timroes/axmlrpc/serializer/DateTimeSerializer.java
@@ -16,7 +16,7 @@ import fr.turri.jiso8601.Iso8601Deserializer;
 public class DateTimeSerializer implements Serializer {
 
 	private static final String DATETIME_FORMAT = "yyyyMMdd'T'HHmmss";
-	private static final SimpleDateFormat DATE_FORMATER = new SimpleDateFormat(DATETIME_FORMAT);
+	private final SimpleDateFormat DATE_FORMATER = new SimpleDateFormat(DATETIME_FORMAT);
 
 	@Override
 	public Object deserialize(Element content) throws XMLRPCException {

--- a/src/main/java/de/timroes/axmlrpc/serializer/SerializerHandler.java
+++ b/src/main/java/de/timroes/axmlrpc/serializer/SerializerHandler.java
@@ -114,7 +114,7 @@ public class SerializerHandler {
 		// Grep type element from inside value element
 		element = XMLUtil.getOnlyChildElement(element.getChildNodes());
 
-		Serializer s = null;
+		Serializer s;
 
 		String type;
 
@@ -169,7 +169,7 @@ public class SerializerHandler {
 	 */
 	public XmlElement serialize(Object object) throws XMLRPCException {
 
-		Serializer s = null;
+		Serializer s;
 
 		if((flags & XMLRPCClient.FLAGS_NIL) != 0 && object == null) {
 			s = nil;

--- a/src/main/java/de/timroes/base64/Base64.java
+++ b/src/main/java/de/timroes/base64/Base64.java
@@ -14,6 +14,8 @@ public class Base64 {
 
 	private static final HashMap<Character,Byte> map = new HashMap<Character, Byte>();
 
+	private Base64() {}
+
 	static {
 		for(int i = 0; i < code.length; i++) {
 			map.put(code[i], (byte)i);


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules
squid:S1118 - Utility classes should not have public constructors.
squid:S1854 - Dead stores should be removed.
squid:S1165 - Exception classes should be immutable.
squid:S2885 - "Calendars" and "DateFormats" should not be static.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1118
https://dev.eclipse.org/sonar/rules/show/squid:S1854
https://dev.eclipse.org/sonar/rules/show/squid:S1165
https://dev.eclipse.org/sonar/rules/show/squid:S2885
Please let me know if you have any questions.
George Kankava