### PR TITLE
Multiple code improvements - squid:S1213, squid:S1226, squid:S1193, squid:UselessParenthesesCheck, squid:HiddenFieldCheck, squid:S1066

### DIFF
--- a/src/main/java/de/timroes/axmlrpc/Call.java
+++ b/src/main/java/de/timroes/axmlrpc/Call.java
@@ -57,11 +57,11 @@ public class Call {
 		methodCall.addChildren(methodName);
 
 		if(params != null && params.length > 0) {
-			XmlElement params = new XmlElement(XMLRPCClient.PARAMS);
-			methodCall.addChildren(params);
+			XmlElement callParams = new XmlElement(XMLRPCClient.PARAMS);
+			methodCall.addChildren(callParams);
 
 			for(Object o : this.params) {
-				params.addChildren(getXMLParam(o));
+				callParams.addChildren(getXMLParam(o));
 			}
 		}
 

--- a/src/main/java/de/timroes/axmlrpc/ResponseParser.java
+++ b/src/main/java/de/timroes/axmlrpc/ResponseParser.java
@@ -81,13 +81,10 @@ class ResponseParser {
 
 			throw new XMLRPCException("The methodResponse tag must contain a fault or params tag.");
 
+		} catch(XMLRPCServerException e) {
+			throw e;
 		} catch (Exception ex) {
-
-			if(ex instanceof XMLRPCServerException)
-				throw (XMLRPCServerException)ex;
-			else
-				throw new XMLRPCException("Error getting result from server.", ex);
-
+			throw new XMLRPCException("Error getting result from server.", ex);
 		}
 
 	}
@@ -116,9 +113,9 @@ class ResponseParser {
 	 */
 	private Object getReturnValueFromElement(Element element) throws XMLRPCException {
 
-		element = XMLUtil.getOnlyChildElement(element.getChildNodes());
+		Element childElement = XMLUtil.getOnlyChildElement(element.getChildNodes());
 
-		return SerializerHandler.getDefault().deserialize(element);
+		return SerializerHandler.getDefault().deserialize(childElement);
 
 	}
 

--- a/src/main/java/de/timroes/axmlrpc/XMLRPCClient.java
+++ b/src/main/java/de/timroes/axmlrpc/XMLRPCClient.java
@@ -698,7 +698,7 @@ public class XMLRPCClient {
 						|| statusCode == HttpURLConnection.HTTP_MOVED_TEMP) {
 					// ... do either a foward
 					if(isFlagSet(FLAGS_FORWARD)) {
-						boolean temporaryForward = (statusCode == HttpURLConnection.HTTP_MOVED_TEMP);
+						boolean temporaryForward = statusCode == HttpURLConnection.HTTP_MOVED_TEMP;
 
 						// Get new location from header field.
 						String newLocation = http.getHeaderField("Location");
@@ -733,10 +733,8 @@ public class XMLRPCClient {
 				}
 
 				// Check for strict parameters
-				if(isFlagSet(FLAGS_STRICT)) {
-					if(!http.getContentType().startsWith(TYPE_XML)) {
-						throw new XMLRPCException("The Content-Type of the response must be text/xml.");
-					}
+				if(isFlagSet(FLAGS_STRICT) && !http.getContentType().startsWith(TYPE_XML)) {
+					throw new XMLRPCException("The Content-Type of the response must be text/xml.");
 				}
 
 				cookieManager.readCookies(http);

--- a/src/main/java/de/timroes/axmlrpc/serializer/BooleanSerializer.java
+++ b/src/main/java/de/timroes/axmlrpc/serializer/BooleanSerializer.java
@@ -12,7 +12,7 @@ import org.w3c.dom.Element;
 public class BooleanSerializer implements Serializer {
 
 	public Object deserialize(Element content) throws XMLRPCException {
-		return (XMLUtil.getOnlyTextContent(content.getChildNodes()).equals("1"))
+		return XMLUtil.getOnlyTextContent(content.getChildNodes()).equals("1")
 				? Boolean.TRUE : Boolean.FALSE;
 	}
 

--- a/src/main/java/de/timroes/base64/Base64.java
+++ b/src/main/java/de/timroes/base64/Base64.java
@@ -44,10 +44,10 @@ public class Base64 {
 		int outi = 0;
 		int b1, b2, b3, b4;
 		for(int i = 0; i < input.length; i+=4) {
-			b1 = (map.get(input[i]) - 1);
-			b2 = (map.get(input[i+1]) - 1);
-			b3 = (map.get(input[i+2]) - 1);
-			b4 = (map.get(input[i+3]) - 1);
+			b1 = map.get(input[i]) - 1;
+			b2 = map.get(input[i+1]) - 1;
+			b3 = map.get(input[i+2]) - 1;
+			b4 = map.get(input[i+3]) - 1;
 			out[outi++] = (byte)(b1 << 2 | b2 >>> 4);
 			out[outi++] = (byte)((b2 & 0x0F) << 4 | b3 >>> 2);
 			out[outi++] = (byte)((b3 & 0x03) << 6 | (b4 & 0x3F));


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules
squid:S1213 - The members of an interface declaration or class should appear in a pre-defined order.
squid:S1226 - Method parameters, caught exceptions and foreach variables should not be reassigned.
squid:S1193 - Exception types should not be tested using "instanceof" in catch blocks.
squid:UselessParenthesesCheck - Useless parentheses around expressions should be removed to prevent any misunderstanding.
squid:HiddenFieldCheck - Local variables should not shadow class fields.
squid:S1066 - Collapsible "if" statements should be merged.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1213
https://dev.eclipse.org/sonar/rules/show/squid:S1226
https://dev.eclipse.org/sonar/rules/show/squid:S1193
https://dev.eclipse.org/sonar/rules/show/squid:UselessParenthesesCheck
https://dev.eclipse.org/sonar/rules/show/squid:HiddenFieldCheck
https://dev.eclipse.org/sonar/rules/show/squid:S1066
Please let me know if you have any questions.
George Kankava