### PR TITLE
Allow nullable dateTime.iso8601 elements

### DIFF
--- a/src/main/java/de/timroes/axmlrpc/serializer/DateTimeSerializer.java
+++ b/src/main/java/de/timroes/axmlrpc/serializer/DateTimeSerializer.java
@@ -24,6 +24,8 @@ public class DateTimeSerializer implements Serializer {
 	}
 
 	public Object deserialize(String dateStr) throws XMLRPCException {
+		if (dateStr==null || dateStr.trim().length()==0)
+			return null;
 		try {
 			return Iso8601Deserializer.toDate(dateStr);
 		} catch (Exception ex) {

--- a/src/test/java/de/timroes/axmlrpc/serializer/TestResponseParser.java
+++ b/src/test/java/de/timroes/axmlrpc/serializer/TestResponseParser.java
@@ -1,6 +1,7 @@
 package de.timroes.axmlrpc.serializer;
 
 import java.net.URL;
+import java.util.Date;
 
 import org.junit.Test;
 
@@ -64,5 +65,14 @@ public class TestResponseParser {
 
 	private Object makeDummyCall(int flags) throws Exception {
 		return new XMLRPCClient(new URL("http://localhost:" + port + endPoint), flags).call("dummy_method");
+	}
+
+	@Test
+	public void canParseDateTime() throws Exception {
+		setMockWithXmlRpcContent("<value><dateTime.iso8601>2018-03-06T06:21:20Z</dateTime.iso8601></value>");
+		assertEquals(new Date(118, 2, 6, 7,21,20), makeDummyCall());
+
+		setMockWithXmlRpcContent("<value><dateTime.iso8601/></value>");
+		assertNull(makeDummyCall());
 	}
 }

--- a/src/test/java/de/timroes/axmlrpc/serializer/TestResponseParser.java
+++ b/src/test/java/de/timroes/axmlrpc/serializer/TestResponseParser.java
@@ -1,4 +1,4 @@
-package de.timroes.axmlrpc;
+package de.timroes.axmlrpc.serializer;
 
 import java.net.URL;
 


### PR DESCRIPTION
In my ticket #75 yesterday, you mentioned that you would accept a PR for this issue.
So, here we go.
I added the code to the DateTimeSerializer, wrote a unit test - and fixed the TestResponseParser having the wrong packge (my IDE complained about it).

Regards,
  Stefan