### PR TITLE
 Add poweron architecture ppc64le to travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,1 +1,8 @@
 language: java
+arch:
+   - ppc64le
+   - amd64
+before_install:
+  - if [ $TRAVIS_CPU_ARCH = ppc64le ]; then
+          sudo apt-get install maven ;
+    fi


### PR DESCRIPTION
This is part of the Ubuntu distribution for ppc64le. This helps us simplify testing later when distributions are re-building and re-releasing. For more info tag @gerrith3.