### PR TITLE
Support custom date time format

### DIFF
--- a/src/main/java/de/timroes/axmlrpc/serializer/DateTimeSerializer.java
+++ b/src/main/java/de/timroes/axmlrpc/serializer/DateTimeSerializer.java
@@ -15,13 +15,19 @@ import fr.turri.jiso8601.Iso8601Deserializer;
  */
 public class DateTimeSerializer implements Serializer {
 
-	private static final String DATETIME_FORMAT = "yyyyMMdd'T'HHmmss";
-	private final SimpleDateFormat DATE_FORMATER = new SimpleDateFormat(DATETIME_FORMAT);
+	public static final String DEFAULT_DATETIME_FORMAT = "yyyyMMdd'T'HHmmss";
+	private final SimpleDateFormat dateFormatter;
 
 	private final boolean accepts_null_input;
 
 	public DateTimeSerializer(boolean accepts_null_input) {
 		this.accepts_null_input = accepts_null_input;
+		this.dateFormatter = new SimpleDateFormat(DEFAULT_DATETIME_FORMAT);
+	}
+
+	public DateTimeSerializer(boolean accepts_null_input, String datetimeFormat) {
+		this.accepts_null_input = accepts_null_input;
+		this.dateFormatter = new SimpleDateFormat(datetimeFormat);
 	}
 
 
@@ -45,7 +51,7 @@ public class DateTimeSerializer implements Serializer {
 	@Override
 	public XmlElement serialize(Object object) {
 		return XMLUtil.makeXmlTag(SerializerHandler.TYPE_DATETIME,
-				DATE_FORMATER.format(object));
+				dateFormatter.format(object));
 	}
 
 }

--- a/src/main/java/de/timroes/axmlrpc/serializer/SerializerHandler.java
+++ b/src/main/java/de/timroes/axmlrpc/serializer/SerializerHandler.java
@@ -48,15 +48,17 @@ public class SerializerHandler {
 		this(XMLRPCClient.FLAGS_DEBUG);
 	}
 
-	public SerializerHandler(int flags) {
+	public SerializerHandler(int flags) { this(flags, DateTimeSerializer.DEFAULT_DATETIME_FORMAT); }
+
+	public SerializerHandler(int flags, String datetimeFormat) {
 		this.flags = flags;
 		string = new StringSerializer(
-			(flags & XMLRPCClient.FLAGS_NO_STRING_ENCODE) == 0,
-			(flags & XMLRPCClient.FLAGS_NO_STRING_DECODE) == 0
+				(flags & XMLRPCClient.FLAGS_NO_STRING_ENCODE) == 0,
+				(flags & XMLRPCClient.FLAGS_NO_STRING_DECODE) == 0
 		);
 		struct = new StructSerializer(this);
 		array = new ArraySerializer(this);
-		datetime = new DateTimeSerializer((flags & XMLRPCClient.FLAGS_ACCEPT_NULL_DATES) != 0);
+		datetime = new DateTimeSerializer(shouldAcceptNullDates(flags), datetimeFormat);
 	}
 
 	/**
@@ -195,6 +197,10 @@ public class SerializerHandler {
 
 		return s.serialize(object);
 
+	}
+
+	private boolean shouldAcceptNullDates(int flags) {
+		return (flags & XMLRPCClient.FLAGS_ACCEPT_NULL_DATES) != 0;
 	}
 
 }

--- a/src/test/java/de/timroes/axmlrpc/serializer/TestDateTimeSerializer.java
+++ b/src/test/java/de/timroes/axmlrpc/serializer/TestDateTimeSerializer.java
@@ -120,6 +120,15 @@ public class TestDateTimeSerializer {
 		assertDeserializeEquals(new Date(81, 11, 31, 23, 59, 59), "1981-12-31T23:59:59Z");
 	}
 
+	@Test
+	public void canDoCustomDatetimeSerialization() {
+		String customDatetimeFormat = "yyyyMMdd'T'HH:mm:ss";
+		String expectedSerialization = "\n<dateTime.iso8601>19811231T23:58:59</dateTime.iso8601>\n";
+		Date date = new Date(81, 11, 31, 23, 58, 59);
+		String actualSerialization = new DateTimeSerializer(false, customDatetimeFormat).serialize(date).toString();
+		assertEquals(expectedSerialization, actualSerialization);
+	}
+
 	private void assertDeserializeEquals(Date expected, String toDeserialize) throws Exception {
 		Date date = (Date) new DateTimeSerializer(false).deserialize(toDeserialize);
 		assertEquals(expected, date);


### PR DESCRIPTION
## What changed?

Added custom datetime format support to DateTimeSerializer and SerializerHandler

## Why?
While yyyyMMdd'T'HHmmss is absolutely a valid ISO-8601 format, some older less updated RPC servers don't like it. I had the same issue as https://github.com/gturri/aXMLRPC/issues/74. The third party server wrongly required colons between the HH, mm, and ss. This update allows users in our situation to work around the picky XMLRPC server.

## How can you work around this today?
It's not very easy, but relies on your support for the custom transport

```
boolean debug = false;
SerializerHandler serializerHandler = new SerializerHandler();
String payload = new Call(serializerHandler, "add", 5, 10).getXML(debug);
payload = fixPayloadDatetimeFormat(payload); // Edit the payload string using something like regex to find and replace. 

InputStream istream = sendPayloadWithMyTransport(payload); // use your implementation here

Integer i = (Integer) new ResponseParser.parse(serializerHandler, istream, debug);
```

## How would this work after this MR?
```
boolean debug = false;
String myCustomDatetimeFormat = "yyyyMMdd'T'HH:mm:ss"
SerializerHandler serializerHandler = new SerializerHandler(XMLRPCClient.FLAGS_DEBUG, myCustomDatetimeFormat);
String payload = new Call(serializerHandler, "add", 5, 10).getXML(debug);

InputStream istream = sendPayloadWithMyTransport(payload); // use your implementation here

Integer i = (Integer) new ResponseParser.parse(serializerHandler, istream, debug);
```

## Why not add this option to XMLClient to allow users to avoid custom transport?

It could be done, I looked into it. There wasn't a perfect solution. Essentially XMLRPCClient needs to either have a 4th constructor (or many more depending on if you wanted all the combos) or it needs to have a setDatetimeFormat() function that overwrites the SerializerHandler (meaning serializerHandler could no longer be final). The latter option isn't so bad, but considering this is a niche use case I didn't want to change too much. I'm more than happy to add to this PR if you think it'd be worth it. 

## What happens if the user supplies a bad datetimeFormat?
`SimpleDateFormat` throws an `IllegalArgumentException`
