### PR TITLE
Switch new Byte() to Byte.valueOf()

### DIFF
--- a/src/main/java/de/timroes/axmlrpc/serializer/SerializerHandler.java
+++ b/src/main/java/de/timroes/axmlrpc/serializer/SerializerHandler.java
@@ -183,7 +183,7 @@ public class SerializerHandler {
 			byte[] old = (byte[])object;
 			Byte[] boxed = new Byte[old.length];
 			for(int i = 0; i < boxed.length; i++) {
-				boxed[i] = new Byte(old[i]);
+				boxed[i] = Byte.valueOf(old[i]);
 			}
 			object = boxed;
 			s = base64;


### PR DESCRIPTION
The Byte() constructors were deprecated in Java 9. Switch to valueOf() instead.

`mvn test` passes.