### PR TITLE
Set SocketTimeoutException as cause

### DIFF
--- a/src/main/java/de/timroes/axmlrpc/XMLRPCClient.java
+++ b/src/main/java/de/timroes/axmlrpc/XMLRPCClient.java
@@ -812,7 +812,7 @@ public class XMLRPCClient {
 				return responseParser.parse(serializerHandler, istream, isFlagSet(FLAGS_DEBUG));
 
 			} catch(SocketTimeoutException ex) {
-				throw new XMLRPCTimeoutException("The XMLRPC call timed out.");
+				throw new XMLRPCTimeoutException("The XMLRPC call timed out.", ex);
 			} catch (IOException ex) {
 				// If the thread has been canceled this exception will be thrown.
 				// So only throw an exception if the thread hasnt been canceled

--- a/src/main/java/de/timroes/axmlrpc/XMLRPCTimeoutException.java
+++ b/src/main/java/de/timroes/axmlrpc/XMLRPCTimeoutException.java
@@ -7,9 +7,11 @@ package de.timroes.axmlrpc;
  * @author Tim Roes
  */
 public class XMLRPCTimeoutException extends XMLRPCException {
-
 	XMLRPCTimeoutException(String ex) {
 		super(ex);
 	}
 
+	XMLRPCTimeoutException(String message, Exception cause) {
+		super(message, cause);
+	}
 }


### PR DESCRIPTION
On timeouts, don't lose the underlying exception, but set it as the thrown exception's cause.